### PR TITLE
fix: showing 00 when read time is zero

### DIFF
--- a/pages/posts/[id].tsx
+++ b/pages/posts/[id].tsx
@@ -427,8 +427,8 @@ export default function PostPage({ id }: Props): ReactElement {
               <Metadata as="time" dateTime={postById?.post?.createdAt}>
                 {postById && postDateFormat(postById.post.createdAt)}
               </Metadata>
-              {postById?.post.readTime && <MetadataSeparator />}
-              {postById?.post.readTime && (
+              {!!postById?.post.readTime && <MetadataSeparator />}
+              {!!postById?.post.readTime && (
                 <Metadata data-testid="readTime">
                   {postById?.post.readTime}m read time
                 </Metadata>


### PR DESCRIPTION
There was a weird behavior when the post read time is set to zero.
This fix converts read time to boolean to decide whether to show it or not