### PR TITLE
fix: truncate long portfolio links

### DIFF
--- a/__tests__/ProfileLayout.tsx
+++ b/__tests__/ProfileLayout.tsx
@@ -38,7 +38,7 @@ const defaultProfile: PublicProfile = {
   createdAt: '2020-08-26T13:04:35.000Z',
   twitter: 'dailydotdev',
   github: 'dailydotdev',
-  portfolio: 'https://daily.dev',
+  portfolio: 'https://daily.dev/?key=vaue',
 };
 
 const renderComponent = (
@@ -86,6 +86,6 @@ it('should show github link', () => {
 it('should show portfolio link', () => {
   renderComponent();
   const el = screen.getByTitle('Go to portfolio website');
-  expect(el).toHaveAttribute('href', 'https://daily.dev');
+  expect(el).toHaveAttribute('href', 'https://daily.dev/?key=vaue');
   expect(el).toHaveTextContent('daily.dev');
 });

--- a/components/layouts/ProfileLayout.tsx
+++ b/components/layouts/ProfileLayout.tsx
@@ -174,6 +174,8 @@ const ProfileHeader = styled.section`
     flex-direction: row;
     margin-left: -${size4};
     margin-right: -${size4};
+    align-self: stretch;
+    overflow-x: hidden;
 
     & > * {
       margin-left: ${size4};
@@ -400,7 +402,11 @@ export default function ProfileLayout({
                   rel="noopener noreferrer"
                 >
                   <LinkIcon />
-                  <span>{portfolioLink.replace(/(^\w+:|^)\/\//, '')}</span>
+                  <span>
+                    {portfolioLink
+                      .replace(/(^\w+:|^)\/\//, '')
+                      .replace(/\/?(\?.*)?$/, '')}
+                  </span>
                 </a>
               )}
             </Links>


### PR DESCRIPTION
Remove trailing slash and query params from portfolio links before showing them.
In case the link is still long, it will be truncated.

Closes #131